### PR TITLE
Fix compile warning for main not returning a value

### DIFF
--- a/pi_code/countbits.c
+++ b/pi_code/countbits.c
@@ -29,4 +29,5 @@ int main (int argc, char *argv[])
 	}
 	printf("Distance = %6d us, %6.2f inches\n", count, (float)count / 148.0f);
 	
+	return 0;
 }


### PR DESCRIPTION
Main did not return, I added a return 0; to the end to fix the warning.